### PR TITLE
Fix description of create_sub_devices()

### DIFF
--- a/source/iface/device.rst
+++ b/source/iface/device.rst
@@ -135,7 +135,7 @@ create_sub_devices
    prop == info::partition_property::partition_equally*
 
   template <info::partition_property prop>
-  vector_class<device> create_sub_devices(size_t nbSubDev) const;
+  vector_class<device> create_sub_devices(size_t count) const;
 
   *Available only when:
    prop == info::partition_property::partition_by_counts*
@@ -162,8 +162,8 @@ prop               See `sycl::info::partition_property`_
 .. rubric:: Parameters
 
 =================  ===
-nbSubDev           Number of subdevices
-counts             Vector of sizes for the subdevices
+count              Number of compute units per subdevice
+counts             Vector with number of compute units for each subdevice
 affinityDomain     See `sycl::info::partition_affinity_domain`_
 =================  ===
 


### PR DESCRIPTION
The parameter to `create_sub_devices()` for `info::partition_property::partition_equally` is the number of compute units for each sub device (not the number of sub devices to create).  This matches the existing DPC++ implementation.  It also matches all other existing SYCL implementations, matches the OpenCL behavior, and the SYCL 2020 spec has been updated to make this clear.

I also clarified that that elements of the `counts` array for `info::partition_property::partition_by_counts` are the number of compute units for each created sub device.