### PR TITLE
Add missing "accessed" in buffer doc

### DIFF
--- a/source/iface/buffer.rst
+++ b/source/iface/buffer.rst
@@ -30,7 +30,7 @@ AllocatorT        Allocator for buffer data
 ================  ==========
 
 Buffers are containers for data that can be read/written by both
-kernel and host.  Data in a buffer cannot be directly via
+kernel and host.  Data in a buffer cannot be accessed directly via
 pointers. Instead, a program creates an :ref:`buffer-accessor` that
 references the buffer. The accessor provides array-like interfaces to
 read/write actual data.  Accessors indicate when they read or write


### PR DESCRIPTION
Data in a buffer cannot be directly
->
Data in a buffer cannot be accessed directly